### PR TITLE
Fix $ and quit $ substitutions

### DIFF
--- a/Generic/exec.c
+++ b/Generic/exec.c
@@ -332,6 +332,12 @@ static int wordcode_match(const char **pvarname,char *fill_buff,
     return 1;
   }
 
+  // WORKAROUND: $You$ substitution on win/lose message
+  if ((winflag || deadflag) && pronoun_mode && match_str(pvarname, "YOU$")) {
+    youme("I", "you");
+    return 1;
+  }
+
   if (context==MSG_MAIN) return 0; 
 
   if (context==MSG_PARSE) {
@@ -357,7 +363,7 @@ static int wordcode_match(const char **pvarname,char *fill_buff,
     just_seen_adj=get_adj(dobj_rec,fill_buff);
     return 1;
   }
-  if (match_str(pvarname,"PREP$"))
+  if (match_str(pvarname,"PREP$") || match_str(pvarname,"PREP_$"))
     d2buff(prep);
   if (match_str(pvarname,"N_PRO$"))
     d2buff(it_pronoun(dobj,0));


### PR DESCRIPTION
In at least Shades of Gray, death results in the message `***** $You$ have died! *****` with weird dollar signs.

This commit changes this to `***** You have died! *****`.

It is based on ScummVM commit c164cc7, which actually fixes another substitution bug in the ScummVM AGT engine as well, but one which I can't reproduce in Windows AGiliTy.

See https://bugs.scummvm.org/ticket/12799 and https://github.com/scummvm/scummvm/commit/c164cc73f73d9c2326bab98f6b37af096e064016.